### PR TITLE
Add milvus profile and test.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,6 +32,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Install jq
+        uses: dcarbone/install-jq-action@v3.2.0
       - uses: ddev/github-action-add-on-test@v2
         with:
           ddev_version: ${{ matrix.ddev_version }}

--- a/README.md
+++ b/README.md
@@ -30,7 +30,23 @@ After installation, make sure to commit the `.ddev` directory to version control
 | `ddev describe`       | View service status and used ports for AI services |
 | `ddev logs -s milvus` | Check Milvus logs                                  |
 
-### Drupal
+### Profiles
+
+Over time we will likely add support for a variety of AI services. Each unique
+product might require several services to work together, such as Milvus. This
+addon leverages the profiles feature from DDEV 1.24+ in order to group related
+services together. See https://ddev.readthedocs.io/en/stable/users/extend/custom-compose-files/#optional-services.
+
+Most of the time you will need to use the profiles flag to start the services
+you want to use:
+
+- Milvus: `ddev start --profiles='milvus'`
+
+### CMS Configuration
+
+#### Drupal
+
+##### Milvus Vector Database Provider for Drupal AI
 
 1. `composer require drupal/ai_vdb_provider_milvus`
 2. `drush en ai_vdb_provider_milvus`

--- a/docker-compose.ai.yaml
+++ b/docker-compose.ai.yaml
@@ -1,5 +1,9 @@
 #ddev-generated
 # See https://www.drupal.org/project/ai/issues/3479943#comment-15809663
+x-ddev-common-ai-labels: &ddev-common-ai-labels
+  com.ddev.site-name: ${DDEV_SITENAME}
+  com.ddev.approot: ${DDEV_APPROOT}
+
 services:
   etcd:
     container_name: ddev-${DDEV_SITENAME}-etcd
@@ -17,9 +21,9 @@ services:
       interval: 30s
       timeout: 20s
       retries: 3
-    labels:
-      com.ddev.site-name: ${DDEV_SITENAME}
-      com.ddev.approot: ${DDEV_APPROOT}
+    labels: *ddev-common-ai-labels
+    profiles:
+      - milvus
   minio:
     container_name: ddev-${DDEV_SITENAME}-minio
     image: minio/minio:RELEASE.2023-03-20T20-16-18Z
@@ -37,9 +41,9 @@ services:
       interval: 30s
       timeout: 20s
       retries: 3
-    labels:
-      com.ddev.site-name: ${DDEV_SITENAME}
-      com.ddev.approot: ${DDEV_APPROOT}
+    labels: *ddev-common-ai-labels
+    profiles:
+      - milvus
   milvus:
     container_name: ddev-${DDEV_SITENAME}-milvus
     image: milvusdb/milvus:v2.4.1
@@ -64,9 +68,9 @@ services:
     depends_on:
       - "etcd"
       - "minio"
-    labels:
-      com.ddev.site-name: ${DDEV_SITENAME}
-      com.ddev.approot: ${DDEV_APPROOT}
+    labels: *ddev-common-ai-labels
+    profiles:
+      - milvus
   attu:
     container_name: ddev-${DDEV_SITENAME}-attu
     image: zilliz/attu:v2.3.10
@@ -80,6 +84,6 @@ services:
       - SERVER_NAME=${DDEV_SITENAME}.ddev.site
     depends_on:
       - "milvus"
-    labels:
-      com.ddev.site-name: ${DDEV_SITENAME}
-      com.ddev.approot: ${DDEV_APPROOT}
+    labels: *ddev-common-ai-labels
+    profiles:
+      - milvus


### PR DESCRIPTION
## The Issue

- Fixes #4 

<!-- Provide a brief description of the issue. -->

## How This PR Solves The Issue

<!-- Describe the key change(s) in this PR that address the issue above. -->
- Moves milvus functionality into `milvus` Docker Compose profile.

## Manual Testing Instructions

<!-- If this PR changes logic, consider adding additional steps or context to the instructions below. -->

```bash
ddev add-on get https://github.com/lpeabody/ddev-ai/tarball/refs/pull/REPLACE_ME_WITH_THIS_PR_NUMBER/head
ddev start --profiles=milvus
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->
- Adds test for validating the milvus services start as expected.

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
- If already using add-on then you will need to start using `ddev start --profiles=milvus` to start Milvus-related services.